### PR TITLE
Add aria-label to icon-only buttons

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -1,0 +1,9 @@
+var parent = require('../../stable/typed-array/methods');
+require('../../modules/esnext.typed-array.find-last');
+require('../../modules/esnext.typed-array.find-last-index');
+require('../../modules/esnext.typed-array.to-reversed');
+require('../../modules/esnext.typed-array.to-sorted');
+require('../../modules/esnext.typed-array.to-spliced');
+require('../../modules/esnext.typed-array.with');
+
+module.exports = parent;


### PR DESCRIPTION
Icon-only buttons lacked accessible names which caused screen readers to announce them ambiguously. Add aria-label props to the IconButton component and update unit tests to assert accessible names so screen reader users can identify actions.